### PR TITLE
Use npm start shortcut

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,7 @@ from npm:
 
     npm install graffeine
 
-    cd node_modules/graffeine
-
-    npm start
+    npm start graffeine
 
 point a browser at:
 


### PR DESCRIPTION
No need to cd into `node_modules`, `npm start` lets you specify a module to start
